### PR TITLE
Changed tests to avoid truncate and decouple them a little bit

### DIFF
--- a/test/auth.js
+++ b/test/auth.js
@@ -7,9 +7,15 @@ var Promise     = require('bluebird'),
 
 module.exports = function(testData) {
   var authToken;
+  var testUser = {
+    'name': 'test user',
+    'email': 'test@email.com',
+    'password': 'pass123'
+  };
+
   describe('Auth tests', function() {
     after(function(done) {
-      models.User.truncate({ logging: false })
+      models.User.destroy({ where: { email: testUser.email }, logging: false })
       .asCallback(done);
     });
 
@@ -17,7 +23,7 @@ module.exports = function(testData) {
       rp({
         method: 'POST',
         uri: (testData.baseURL + '/auth/register'),
-        form: testData.users[0]
+        form: testUser
       })
       .then(function(response) {
         var result = JSON.parse(response);
@@ -37,7 +43,7 @@ module.exports = function(testData) {
       rp({
         method: 'POST',
         uri: (testData.baseURL + '/auth/register'),
-        form: testData.users[0]
+        form: testUser
       })
       .then(function(response) {
         done('should have responded with an error status when creating the user');
@@ -53,8 +59,8 @@ module.exports = function(testData) {
         method: 'POST',
         uri: (testData.baseURL + '/auth/email'),
         form: {
-          'email': testData.users[0].email,
-          'password': testData.users[0].password
+          'email': testUser.email,
+          'password': testUser.password
         }
       })
       .then(function(response) {
@@ -102,8 +108,8 @@ module.exports = function(testData) {
     });
 
     it('should fail to access a secured endpoint with a valid JWT but non-existing user', function (done) {
-      models.User.truncate({ logging: false })
-      .then(function() {
+      models.User.destroy({ where: { email: testUser.email }, logging: false })
+      .then(function(res) {
         return rp({
           method: 'POST',
           uri: (testData.baseURL + '/auth/refresh'),

--- a/test/index.js
+++ b/test/index.js
@@ -3,24 +3,7 @@ var expect    = require('chai').expect,
     usersTest = require('./users.js'),
     rolesTest = require('./roles.js'),
     testData  = {
-      baseURL: process.env.TEST_URL || 'http://localhost:5000',
-      users: [
-        {
-          'name': 'test user',
-          'email': 'test@email.com',
-          'password': 'pass123'
-        },
-        {
-          'name': 'test user2',
-          'email': 'test2@email.com',
-          'password': 'pass123'
-        },
-        {
-          'name': 'test user3',
-          'email': 'test3@email.com',
-          'password': 'pass123'
-        }
-      ]
+      baseURL: process.env.TEST_URL || 'http://localhost:5000'
     };
 
 describe('Test Suite', function() {

--- a/test/roles.js
+++ b/test/roles.js
@@ -8,15 +8,22 @@ var Promise     = require('bluebird'),
 module.exports = function(testData) {
   describe('Roles tests', function() {
     var user, token;
-    after(function() {
-      return models.User.truncate({ logging: false });
+    var testUser = {
+      'name': 'test user',
+      'email': 'test@email.com',
+      'password': 'pass123'
+    };
+
+    after(function(done) {
+      models.User.destroy({ where: { email: testUser.email }, logging: false })
+      .asCallback(done);
     });
 
     before(function(done) {
       rp({
         method: 'POST',
         uri: (testData.baseURL + '/auth/register'),
-        form: testData.users[0]
+        form: testUser
       })
       .then(function(res) {
         res = JSON.parse(res);

--- a/test/users.js
+++ b/test/users.js
@@ -7,16 +7,49 @@ var Promise     = require('bluebird'),
 
 module.exports = function(testData) {
   var ids = [], tokens = [];
+  var users = [
+    {
+      'name': 'test user',
+      'email': 'test@email.com',
+      'password': 'pass123'
+    },
+    {
+      'name': 'test user2',
+      'email': 'test2@email.com',
+      'password': 'pass123'
+    },
+    {
+      'name': 'test user3',
+      'email': 'test3@email.com',
+      'password': 'pass123'
+    }
+  ];
   describe('Users tests', function() {
-    after(function() {
-      return models.User.truncate({ logging: false });
+    after(function(done) {
+      models.User.destroy({
+        where: {
+          $or: [
+            {
+              email: users[0].email
+            },
+            {
+              email: users[1].email
+            },
+            {
+              email: users[2].email
+            }
+          ]
+        },
+        logging: false
+      })
+      .asCallback(done);
     });
 
     before(function(done) {
       rp({  //Ordered inserts to test sort/limit/offset endpoints
         method: 'POST',
         uri: (testData.baseURL + '/auth/register'),
-        form: testData.users[0]
+        form: users[0]
       })
       .then(function(usr) {
         usr = JSON.parse(usr);
@@ -25,7 +58,7 @@ module.exports = function(testData) {
         return rp({
           method: 'POST',
           uri: (testData.baseURL + '/auth/register'),
-          form: testData.users[1]
+          form: users[1]
         });
       })
       .then(function(usr) {
@@ -35,7 +68,7 @@ module.exports = function(testData) {
         return rp({
           method: 'POST',
           uri: (testData.baseURL + '/auth/register'),
-          form: testData.users[2]
+          form: users[2]
         });
       })
       .then(function(usr) {
@@ -128,7 +161,7 @@ module.exports = function(testData) {
       .then(function(response) {
         var result = JSON.parse(response);
         expect(result).to.have.lengthOf(1);
-        expect(result[0]).to.have.property('name', testData.users[1].name);
+        expect(result[0]).to.have.property('name', users[1].name);
         done();
       })
       .catch(function(err) {
@@ -145,8 +178,8 @@ module.exports = function(testData) {
       })
       .then(function(response) {
         var result = JSON.parse(response);
-        expect(result).to.have.property('name', testData.users[0].name);
-        expect(result).to.have.property('email', testData.users[0].email);
+        expect(result).to.have.property('name', users[0].name);
+        expect(result).to.have.property('email', users[0].email);
         expect(result).to.not.have.property('password');
         done();
       })
@@ -164,8 +197,8 @@ module.exports = function(testData) {
       })
       .then(function(response) {
         var result = JSON.parse(response);
-        expect(result).to.have.property('name', testData.users[1].name);
-        expect(result).to.have.property('email', testData.users[1].email);
+        expect(result).to.have.property('name', users[1].name);
+        expect(result).to.have.property('email', users[1].email);
         expect(result).to.not.have.property('password');
         done();
       })


### PR DESCRIPTION
Now each test file will have to create its own data in the `before` hook and will be responsible for cleaning up in the `after` hook.

Will avoid `truncate` function from now on because of problems that might arise in the future (constraints/foreign keys).
